### PR TITLE
Added option whether to include javascript in generated HTML

### DIFF
--- a/src/Args.hs
+++ b/src/Args.hs
@@ -1,4 +1,12 @@
-module Args (args, Args(..), Uniform(..), Sort(..), KeyPlace(..), TitlePlace(..)) where
+module Args
+  (
+    args
+  , Args(..)
+  , Uniform(..)
+  , Sort(..)
+  , KeyPlace(..)
+  , TitlePlace(..)
+  ) where
 
 import Options.Applicative
 import Data.Semigroup ((<>))
@@ -19,6 +27,7 @@ data Args = Args
   , patterned    :: Bool
   , eventlog     :: Bool
   , test         :: Bool
+  , includejs    :: Bool
   , json         :: Bool
   , files        :: [String]
   }
@@ -70,13 +79,16 @@ argParser = Args
       <*> switch
           (short 't')
       <*> switch
+          (long "include-js"
+          <> help "Include the javascript into the generated HTML instead of fetching it from a CDN.")
+      <*> switch
           ( long "json"
           <> short 'j'
           <> help "Output JSON")
-
       <*> some (argument str
           ( help "Heap profiles (FILE.hp will be converted to FILE.svg)."
          <> metavar "FILES..." ))
+
 
 parseUniform :: ReadM Uniform
 parseUniform = eitherReader $ \s -> case s of

--- a/src/HtmlTemplate.hs
+++ b/src/HtmlTemplate.hs
@@ -6,19 +6,27 @@ import Data.Text (Text, append)
 import Text.Blaze.Html5            as H
 import Text.Blaze.Html5.Attributes as A
 import Javascript
+import Args
 
 encloseScript :: Text -> Html
 encloseScript vegaspec = preEscapedToHtml $
   "var yourVlSpec = " `append` vegaspec `append` ";\n vegaEmbed('#vis', yourVlSpec);"
 
-template :: Html -> Html
-template vegaSpec = docTypeHtml $ do
+template :: Args -> Html -> Html
+template args vegaSpec = docTypeHtml $ do
   H.head $ do
     H.title "Heap Profile"
     meta ! charset "UTF-8"
-    script $ preEscapedToHtml vegaLite
-    script $ preEscapedToHtml vega
-    script $ preEscapedToHtml vegaEmbed
+    if includejs args
+      then do
+        script $ preEscapedToHtml vegaLite
+        script $ preEscapedToHtml vega
+        script $ preEscapedToHtml vegaEmbed
+      else do
+        script ! src "https://cdn.jsdelivr.net/npm/vega@5.4.0" $ ""
+        script ! src "https://cdn.jsdelivr.net/npm/vega-lite@3.3.0" $ ""
+        script ! src "https://cdn.jsdelivr.net/npm/vega-embed@4.2.0" $ ""
+      
   body $ do
     h1 $ "Heap Profile"
     H.div ! A.id "vis" $ ""

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -150,7 +150,7 @@ doJson a = do
     --let mybands = encode (bandsToVega keeps (bands h keeps fs))
     --let mytraces = (tracesToVega traces)
     let vegaspec =  toStrict (encodeToLazyText (fromVL (vegaResult (T.pack (file <.> "json"))(T.pack (file <.> "json" <.> "traces")))))
-    let html = renderHtml (template (encloseScript vegaspec))
+    let html = renderHtml (template a (encloseScript vegaspec))
     let filename2 = file <.> "html"
     writeFile filename2 html
     exitSuccess


### PR DESCRIPTION
The command line option "--include-js" enables the insertion of javascript into the generated HTML file.

Difference in file size of ghc.eventlog.html:
- without "--include-js": 2.5Kb
- with "--include-js": 698Kb

Resolves: #10 